### PR TITLE
Allow workspace_config to be a function

### DIFF
--- a/test/lsp/utils/workspace_config.vimspec
+++ b/test/lsp/utils/workspace_config.vimspec
@@ -1,22 +1,53 @@
 Describe lsp#utils#workspace_config
 
     Describe lsp#utils#workspace_config#get
-        It should return the registered workspace config
+        It should return the workspace config, when it is a dict
+            let l:name = 'Unit Test Server'
+
             call lsp#register_server({
-                \     'name': 'Unit Test Server',
+                \     'name': l:name,
                 \     'workspace_config': {
                 \         'a': {
                 \             'a1': v:true,
                 \             'a2': {
-                \                 'a21': 'disabled'
-                \             }
+                \                 'a21': 'disabled',
+                \             },
                 \         },
-                \         'b': 'path/to/file'
+                \         'b': 'path/to/file',
                 \     }
                 \ })
 
-            let l:config = lsp#utils#workspace_config#get('Unit Test Server')
+            let l:config = lsp#utils#workspace_config#get(l:name)
 
+            Assert Equals(l:config['a']['a1'], v:true)
+            Assert Equals(l:config['a']['a2']['a21'], 'disabled')
+            Assert Equals(l:config['b'], 'path/to/file')
+        end
+
+        It should return the workspace config, produced by a callback
+            let l:name = 'Unit Test Server'
+
+            let l:callResult = {}
+
+            call lsp#register_server({
+                \     'name': l:name,
+                \     'workspace_config': {server_info->l:callResult},
+                \ })
+
+            let l:config = lsp#utils#workspace_config#get(l:name)
+            Assert Equals(l:config, {})
+
+            let l:callResult = {
+                \     'a': {
+                \         'a1': v:true,
+                \         'a2': {
+                \             'a21': 'disabled',
+                \         },
+                \     },
+                \     'b': 'path/to/file'
+                \ }
+
+            let l:config = lsp#utils#workspace_config#get(l:name)
             Assert Equals(l:config['a']['a1'], v:true)
             Assert Equals(l:config['a']['a2']['a21'], 'disabled')
             Assert Equals(l:config['b'], 'path/to/file')
@@ -29,27 +60,27 @@ Describe lsp#utils#workspace_config
                 \     'a': {
                 \         'a1': v:true,
                 \         'a2': {
-                \             'a21': 'disabled'
-                \         }
+                \             'a21': 'disabled',
+                \         },
                 \     },
-                \     'b': 'path/to/file'
+                \     'b': 'path/to/file',
                 \ }
 
             let l:config_a_a1 = lsp#utils#workspace_config#projection(
                 \     l:config,
-                \     { 'section': 'a.a1' }
+                \     { 'section': 'a.a1' },
                 \ )
             let l:config_a_a2_a21 = lsp#utils#workspace_config#projection(
                 \     l:config,
-                \     { 'section': 'a.a2.a21' }
+                \     { 'section': 'a.a2.a21' },
                 \ )
             let l:config_b = lsp#utils#workspace_config#projection(
                 \     l:config,
-                \     { 'section': 'b' }
+                \     { 'section': 'b' },
                 \ )
             let l:config_c = lsp#utils#workspace_config#projection(
                 \     l:config,
-                \     { 'section': 'c' }
+                \     { 'section': 'c' },
                 \ )
 
             Assert Equals(l:config_a_a1, v:true)
@@ -60,7 +91,7 @@ Describe lsp#utils#workspace_config
     End
 
     Describe lsp#utils#workspace_config#get_value
-        It should return a porjection of the registered workspace config
+        It should return a projection of the workspace config, when it is a dict
             let l:name = 'Unit Test Server'
 
             call lsp#register_server({
@@ -69,28 +100,77 @@ Describe lsp#utils#workspace_config
                 \         'a': {
                 \             'a1': v:true,
                 \             'a2': {
-                \                 'a21': 'disabled'
+                \                 'a21': 'disabled',
                 \             },
                 \          },
-                \          'b': "path/to/file"
+                \          'b': "path/to/file",
                 \     }
                 \ })
 
             let l:config_a_a1 = lsp#utils#workspace_config#get_value(
                 \     l:name,
-                \     { 'section': 'a.a1' }
+                \     { 'section': 'a.a1' },
                 \ )
             let l:config_a_a2_a21 = lsp#utils#workspace_config#get_value(
                 \     l:name,
-                \     { 'section': 'a.a2.a21' }
+                \     { 'section': 'a.a2.a21' },
                 \ )
             let l:config_b = lsp#utils#workspace_config#get_value(
                 \     l:name,
-                \     { 'section': 'b' }
+                \     { 'section': 'b' },
                 \ )
             let l:config_c = lsp#utils#workspace_config#get_value(
                 \     l:name,
-                \     { 'section': 'c' }
+                \     { 'section': 'c' },
+                \ )
+
+            Assert Equals(l:config_a_a1, v:true)
+            Assert Equals(l:config_a_a2_a21, 'disabled')
+            Assert Equals(l:config_b, 'path/to/file')
+            Assert Equals(l:config_c, v:null)
+        end
+
+        It should return a projection of the workspace config, produced by a callback
+            let l:name = 'Unit Test Server'
+
+            let l:callResult = {}
+
+            call lsp#register_server({
+                \     'name': l:name,
+                \     'workspace_config': {server_info->l:callResult},
+                \ })
+
+            let l:config = lsp#utils#workspace_config#get_value(
+                \     l:name,
+                \     { 'section': '' },
+                \ )
+            Assert Equals(l:config, {})
+
+            let l:callResult = {
+                \     'a': {
+                \         'a1': v:true,
+                \         'a2': {
+                \             'a21': 'disabled',
+                \         },
+                \      },
+                \      'b': "path/to/file",
+                \ }
+
+            let l:config_a_a1 = lsp#utils#workspace_config#get_value(
+                \     l:name,
+                \     { 'section': 'a.a1' },
+                \ )
+            let l:config_a_a2_a21 = lsp#utils#workspace_config#get_value(
+                \     l:name,
+                \     { 'section': 'a.a2.a21' },
+                \ )
+            let l:config_b = lsp#utils#workspace_config#get_value(
+                \     l:name,
+                \     { 'section': 'b' },
+                \ )
+            let l:config_c = lsp#utils#workspace_config#get_value(
+                \     l:name,
+                \     { 'section': 'c' },
                 \ )
 
             Assert Equals(l:config_a_a1, v:true)


### PR DESCRIPTION
It is sometimes useful to generate `workspace_config` using a callback.
For example, if the produced config needs to include some information
from the actual workspace.